### PR TITLE
[feat]: Adjust the calendar on the booking page so users cant book a date beyond a month

### DIFF
--- a/src/pages/booking.jsx
+++ b/src/pages/booking.jsx
@@ -196,7 +196,10 @@ function Booking() {
           id="date"
           min={new Date(new Date().setDate(new Date().getDate() + 7))
             .toISOString()
-            .split("T")[0]} 
+            .split("T")[0]}
+          max={new Date(new Date().setDate(new Date().getDate() + 28))
+            .toISOString()
+            .split("T")[0]}  
           className='input'
           required/>
       </div>


### PR DESCRIPTION
…

users can no longer pick a booking date that is beyond 3 weeks from the minimum allowed date